### PR TITLE
Rebuild portfolio to mirror reference aesthetic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# chatgpt
-coding ai
+# Portfolio Website
+
+This repository contains a single-page portfolio site for Alex Johnson, a product designer and front-end developer.
+
+## Getting started
+
+Open `index.html` in any modern browser. All assets are static and require no build step.
+
+## Structure
+
+- `index.html` – Landing page with sections for hero, about, work, skills, and contact.
+- `assets/css/styles.css` – Global styles, layout, and responsive behavior.
+- `assets/js/main.js` – Navigation toggle behavior, dynamic year, and scroll animations.

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,622 @@
+:root {
+    --bg: #f5f5f0;
+    --surface: #ffffff;
+    --surface-alt: #f0f0e8;
+    --text: #131417;
+    --muted: #4b4d52;
+    --accent: #2c4cff;
+    --accent-soft: rgba(44, 76, 255, 0.08);
+    --border: rgba(22, 24, 29, 0.08);
+    --shadow: 0 24px 48px rgba(19, 20, 23, 0.08);
+    --radius-lg: 32px;
+    --radius-md: 20px;
+    --radius-sm: 12px;
+    --max-width: 1120px;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    line-height: 1.6;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:hover,
+a:focus {
+    color: var(--accent);
+}
+
+img {
+    max-width: 100%;
+    display: block;
+}
+
+.container {
+    width: min(100%, var(--max-width));
+    margin: 0 auto;
+    padding: 0 1.75rem;
+}
+
+.site-header {
+    position: relative;
+    padding-bottom: 6rem;
+    background: radial-gradient(circle at 10% 10%, rgba(44, 76, 255, 0.12), transparent 60%),
+                radial-gradient(circle at 90% 20%, rgba(44, 76, 255, 0.16), transparent 55%),
+                var(--bg);
+}
+
+.nav {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.5rem;
+    padding: 1.5rem clamp(1.5rem, 3vw, 3rem);
+    backdrop-filter: blur(16px);
+    background: rgba(245, 245, 240, 0.8);
+    border-bottom: 1px solid rgba(22, 24, 29, 0.06);
+}
+
+.nav__logo {
+    font-family: 'Syne', sans-serif;
+    font-weight: 700;
+    font-size: 1.25rem;
+    letter-spacing: 0.08em;
+    padding: 0.4rem 0.85rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+}
+
+.nav__links {
+    display: flex;
+    align-items: center;
+    gap: 1.75rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.nav__links a {
+    font-size: 0.95rem;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    position: relative;
+}
+
+.nav__links a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -0.35rem;
+    width: 100%;
+    height: 1px;
+    background: currentColor;
+    transform: scaleX(0);
+    transform-origin: right;
+    transition: transform 0.25s ease;
+}
+
+.nav__links a:hover::after,
+.nav__links a:focus-visible::after {
+    transform: scaleX(1);
+    transform-origin: left;
+}
+
+.nav__cta {
+    margin-left: auto;
+    font-weight: 600;
+    font-size: 0.95rem;
+    padding: 0.7rem 1.4rem;
+    border-radius: 999px;
+    background: var(--text);
+    color: #fff;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nav__cta:hover,
+.nav__cta:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 28px rgba(19, 20, 23, 0.12);
+}
+
+.nav__toggle {
+    display: none;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.6rem;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: #fff;
+}
+
+.nav__toggle span {
+    display: block;
+    width: 1.3rem;
+    height: 2px;
+    background: var(--text);
+}
+
+.hero {
+    display: grid;
+    grid-template-columns: repeat(12, 1fr);
+    gap: 2rem;
+    padding-top: 5rem;
+}
+
+.hero__copy {
+    grid-column: span 7;
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+}
+
+.hero__eyebrow {
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--muted);
+}
+
+.hero h1 {
+    font-family: 'Syne', sans-serif;
+    font-weight: 700;
+    font-size: clamp(2.8rem, 5vw, 3.8rem);
+    line-height: 1.1;
+    margin: 0;
+}
+
+.hero__lead {
+    max-width: 520px;
+    font-size: 1.1rem;
+    color: var(--muted);
+}
+
+.hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+    font-size: 0.95rem;
+    padding: 0.85rem 1.7rem;
+    border-radius: 999px;
+    border: 1px solid transparent;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.btn--primary {
+    background: var(--accent);
+    color: #fff;
+    box-shadow: 0 16px 32px rgba(44, 76, 255, 0.28);
+}
+
+.btn--primary:hover,
+.btn--primary:focus-visible {
+    transform: translateY(-2px);
+}
+
+.btn--ghost {
+    border-color: rgba(19, 20, 23, 0.1);
+    background: transparent;
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus-visible {
+    border-color: rgba(19, 20, 23, 0.3);
+    color: var(--text);
+}
+
+.hero__stats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 2.25rem;
+}
+
+.hero__stat-number {
+    font-size: 1.4rem;
+    font-weight: 600;
+    display: block;
+}
+
+.hero__stat-label {
+    color: var(--muted);
+    font-size: 0.95rem;
+}
+
+.hero__portrait {
+    grid-column: span 5;
+    display: flex;
+    align-items: flex-end;
+    justify-content: flex-end;
+    padding: 3rem;
+}
+
+.hero__card {
+    width: min(100%, 320px);
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    padding: 2rem;
+    box-shadow: var(--shadow);
+    display: grid;
+    gap: 0.6rem;
+    border: 1px solid var(--border);
+}
+
+.hero__card span {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: var(--muted);
+}
+
+.hero__card strong {
+    font-size: 1.1rem;
+}
+
+.section {
+    padding: clamp(4rem, 9vw, 6.5rem) 0;
+}
+
+.section--alt {
+    background: var(--surface);
+}
+
+.eyebrow {
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.2em;
+    color: var(--muted);
+    margin-bottom: 1.5rem;
+}
+
+.section__grid {
+    display: grid;
+    gap: 3rem;
+    align-items: start;
+}
+
+.section__intro h2 {
+    font-family: 'Syne', sans-serif;
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    margin: 0;
+    line-height: 1.2;
+}
+
+.section__content p {
+    color: var(--muted);
+    margin-bottom: 2rem;
+}
+
+.about__highlights {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.about__highlights h3 {
+    margin-top: 0;
+    font-size: 1.1rem;
+}
+
+.about__highlights ul {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0;
+    display: grid;
+    gap: 0.65rem;
+    color: var(--muted);
+}
+
+.section__intro--split {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1.5rem;
+    justify-content: space-between;
+}
+
+.link-arrow {
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--accent);
+}
+
+.link-arrow::after {
+    content: '→';
+    transition: transform 0.2s ease;
+}
+
+.link-arrow:hover::after,
+.link-arrow:focus-visible::after {
+    transform: translateX(4px);
+}
+
+.projects {
+    display: grid;
+    gap: 2.5rem;
+}
+
+.project {
+    display: grid;
+    gap: 2rem;
+    padding: 2.5rem;
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    box-shadow: 0 24px 48px rgba(19, 20, 23, 0.05);
+}
+
+.project__meta h3 {
+    font-size: 1.6rem;
+    margin: 0 0 1rem;
+}
+
+.project__tag {
+    display: inline-flex;
+    padding: 0.45rem 1.1rem;
+    border-radius: 999px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-weight: 600;
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 1rem;
+}
+
+.project__meta p {
+    color: var(--muted);
+}
+
+.project__meta ul {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0 0;
+    display: grid;
+    gap: 0.6rem;
+    color: var(--muted);
+}
+
+.project__image {
+    border-radius: var(--radius-md);
+    min-height: 220px;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+    border: 1px solid rgba(44, 76, 255, 0.08);
+}
+
+.project__image--nova {
+    background-image: linear-gradient(135deg, rgba(44, 76, 255, 0.25), rgba(16, 38, 94, 0.25)), url('https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=1200&q=80');
+}
+
+.project__image--lumen {
+    background-image: linear-gradient(135deg, rgba(44, 76, 255, 0.2), rgba(255, 94, 98, 0.2)), url('https://images.unsplash.com/photo-1556740749-887f6717d7e4?auto=format&fit=crop&w=1200&q=80');
+}
+
+.project__image--atlas {
+    background-image: linear-gradient(135deg, rgba(44, 76, 255, 0.2), rgba(0, 0, 0, 0.35)), url('https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1200&q=80');
+}
+
+.services {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.service {
+    background: var(--surface);
+    padding: 2rem;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    display: grid;
+    gap: 1rem;
+    transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.service:hover {
+    transform: translateY(-6px);
+    box-shadow: var(--shadow);
+}
+
+.service h3 {
+    margin: 0;
+    font-size: 1.3rem;
+}
+
+.service p {
+    color: var(--muted);
+}
+
+.service ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 0.5rem;
+    color: var(--muted);
+}
+
+.timeline {
+    display: grid;
+    gap: 1.75rem;
+}
+
+.timeline__item {
+    display: grid;
+    gap: 0.8rem;
+    padding: 1.8rem 2rem;
+    background: var(--surface);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    box-shadow: 0 16px 32px rgba(19, 20, 23, 0.04);
+}
+
+.timeline__year {
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--muted);
+    font-size: 0.85rem;
+}
+
+.timeline__content h3 {
+    margin: 0 0 0.5rem;
+}
+
+.timeline__content p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.contact {
+    display: grid;
+    gap: 3rem;
+    align-items: start;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.contact__intro {
+    display: grid;
+    gap: 1.2rem;
+}
+
+.contact__details {
+    display: grid;
+    gap: 0.6rem;
+    font-weight: 600;
+}
+
+.contact__form {
+    display: grid;
+    gap: 0.8rem;
+    padding: 2.5rem;
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--border);
+    box-shadow: var(--shadow);
+}
+
+.contact__form input,
+.contact__form textarea {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    border-radius: var(--radius-sm);
+    border: 1px solid rgba(19, 20, 23, 0.1);
+    font: inherit;
+    background: #fff;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.contact__form input:focus,
+.contact__form textarea:focus {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(44, 76, 255, 0.15);
+}
+
+.footer {
+    padding: 2.5rem 0 3rem;
+    background: var(--surface);
+    border-top: 1px solid rgba(22, 24, 29, 0.06);
+}
+
+.footer__content {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    font-size: 0.9rem;
+    color: var(--muted);
+}
+
+@media (max-width: 960px) {
+    .hero {
+        grid-template-columns: repeat(6, 1fr);
+    }
+
+    .hero__copy {
+        grid-column: span 6;
+    }
+
+    .hero__portrait {
+        grid-column: span 6;
+        justify-content: flex-start;
+        padding: 1rem 0 0;
+    }
+
+    .nav {
+        justify-content: space-between;
+    }
+
+    .nav__links {
+        position: fixed;
+        inset: 72px 1.5rem auto;
+        background: rgba(245, 245, 240, 0.98);
+        border: 1px solid var(--border);
+        border-radius: var(--radius-md);
+        padding: 1.5rem;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1rem;
+        box-shadow: var(--shadow);
+        transform: translateY(-140%);
+        opacity: 0;
+        pointer-events: none;
+        transition: transform 0.3s ease, opacity 0.3s ease;
+    }
+
+    .nav__links.is-open {
+        transform: translateY(0);
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    .nav__cta {
+        display: none;
+    }
+
+    .nav__toggle {
+        display: inline-flex;
+    }
+}
+
+@media (max-width: 640px) {
+    .hero {
+        padding-top: 3.5rem;
+    }
+
+    .hero__stats {
+        gap: 1.5rem;
+    }
+
+    .project {
+        padding: 1.75rem;
+    }
+
+    .contact__form {
+        padding: 2rem;
+    }
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const navToggle = document.querySelector('.nav__toggle');
+    const navLinks = document.querySelector('.nav__links');
+
+    if (navToggle && navLinks) {
+        navToggle.addEventListener('click', () => {
+            const isOpen = navLinks.classList.toggle('is-open');
+            navToggle.setAttribute('aria-expanded', isOpen);
+        });
+    }
+
+    const yearEl = document.getElementById('year');
+    if (yearEl) {
+        yearEl.textContent = new Date().getFullYear();
+    }
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Alex Johnson — Product Designer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Syne:wght@400;500;600;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/styles.css">
+</head>
+<body>
+    <header class="site-header" id="home">
+        <nav class="nav">
+            <a class="nav__logo" href="#home">AJ</a>
+            <button class="nav__toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="primary-nav">
+                <span></span>
+                <span></span>
+            </button>
+            <ul class="nav__links" id="primary-nav">
+                <li><a href="#about">About</a></li>
+                <li><a href="#work">Work</a></li>
+                <li><a href="#services">Services</a></li>
+                <li><a href="#experience">Experience</a></li>
+                <li><a href="#contact">Contact</a></li>
+            </ul>
+            <a class="nav__cta" href="mailto:hello@alexjohnson.design">Let’s talk</a>
+        </nav>
+        <div class="hero container">
+            <div class="hero__copy">
+                <p class="hero__eyebrow">Product Designer · Front-End Developer</p>
+                <h1>Designing thoughtful digital products for fast-moving teams.</h1>
+                <p class="hero__lead">I help SaaS founders and design-led companies craft interfaces that feel effortless to use and deliver measurable outcomes.</p>
+                <div class="hero__actions">
+                    <a class="btn btn--primary" href="#work">View projects</a>
+                    <a class="btn btn--ghost" href="#contact">Book a discovery call</a>
+                </div>
+                <div class="hero__stats">
+                    <div>
+                        <span class="hero__stat-number">8+</span>
+                        <span class="hero__stat-label">Years crafting products</span>
+                    </div>
+                    <div>
+                        <span class="hero__stat-number">24</span>
+                        <span class="hero__stat-label">Products launched</span>
+                    </div>
+                    <div>
+                        <span class="hero__stat-number">4.9<span aria-hidden="true">★</span></span>
+                        <span class="hero__stat-label">Average client rating</span>
+                    </div>
+                </div>
+            </div>
+            <div class="hero__portrait" aria-hidden="true">
+                <div class="hero__card">
+                    <span>Based in Austin, TX</span>
+                    <strong>Currently partnering with growth-stage startups.</strong>
+                </div>
+            </div>
+        </div>
+    </header>
+
+    <main>
+        <section class="section" id="about">
+            <div class="container section__grid">
+                <div class="section__intro">
+                    <p class="eyebrow">About</p>
+                    <h2>Strategic partner from discovery through delivery.</h2>
+                </div>
+                <div class="section__content">
+                    <p>I blend human-centered design with front-end engineering to bring clarity to complex product challenges. Whether you need a new product brought to life or an existing experience elevated, I plug into teams quickly, champion the user, and ship polished solutions.</p>
+                    <div class="about__highlights">
+                        <div>
+                            <h3>What clients appreciate</h3>
+                            <ul>
+                                <li>Structured discovery workshops</li>
+                                <li>High-fidelity prototyping and testing</li>
+                                <li>Developer-friendly component libraries</li>
+                            </ul>
+                        </div>
+                        <div>
+                            <h3>Recent collaborations</h3>
+                            <ul>
+                                <li>Nova Analytics — SaaS dashboard overhaul</li>
+                                <li>Lumen Health — Mobile wellness platform</li>
+                                <li>Atlas Labs — Interactive marketing website</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <section class="section section--alt" id="work">
+            <div class="container">
+                <div class="section__intro section__intro--split">
+                    <div>
+                        <p class="eyebrow">Selected Work</p>
+                        <h2>Launching product experiences that grow with your business.</h2>
+                    </div>
+                    <a class="link-arrow" href="mailto:hello@alexjohnson.design">Request full case studies</a>
+                </div>
+                <div class="projects">
+                    <article class="project">
+                        <div class="project__meta">
+                            <span class="project__tag">SaaS Platform</span>
+                            <h3>Nova Analytics redesign</h3>
+                            <p>Reimagined the entire analytics experience with modular dashboards, multi-tenant theming, and a scalable design system used across five teams.</p>
+                            <ul>
+                                <li>End-to-end UX research</li>
+                                <li>Design system buildout</li>
+                                <li>React front-end handoff</li>
+                            </ul>
+                        </div>
+                        <div class="project__image project__image--nova"></div>
+                    </article>
+                    <article class="project">
+                        <div class="project__meta">
+                            <span class="project__tag">Mobile Product</span>
+                            <h3>Lumen habit coaching</h3>
+                            <p>Launched a personalized wellness companion with habit loops, social accountability, and delightful motion design to increase day-30 retention by 22%.</p>
+                            <ul>
+                                <li>Product strategy & roadmapping</li>
+                                <li>Mobile-first design language</li>
+                                <li>Motion & micro-interactions</li>
+                            </ul>
+                        </div>
+                        <div class="project__image project__image--lumen"></div>
+                    </article>
+                    <article class="project">
+                        <div class="project__meta">
+                            <span class="project__tag">Marketing Site</span>
+                            <h3>Atlas Labs launch</h3>
+                            <p>Partnered with the founding team to ship an immersive storytelling site that increased qualified demo requests 3× within the first quarter.</p>
+                            <ul>
+                                <li>Narrative copywriting</li>
+                                <li>Interactive scroll experiences</li>
+                                <li>Headless CMS integration</li>
+                            </ul>
+                        </div>
+                        <div class="project__image project__image--atlas"></div>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="services">
+            <div class="container">
+                <div class="section__intro">
+                    <p class="eyebrow">Services</p>
+                    <h2>Flexible engagements shaped around your product goals.</h2>
+                </div>
+                <div class="services">
+                    <article class="service">
+                        <h3>Product discovery sprints</h3>
+                        <p>Align stakeholders, define success, and uncover opportunities through collaborative workshops and rapid prototyping.</p>
+                        <ul>
+                            <li>Stakeholder interviews</li>
+                            <li>Journey & service mapping</li>
+                            <li>Prototype validation</li>
+                        </ul>
+                    </article>
+                    <article class="service">
+                        <h3>Experience design systems</h3>
+                        <p>Craft modular UI kits and documentation so engineering teams can ship faster with consistency built in.</p>
+                        <ul>
+                            <li>Component architecture</li>
+                            <li>Design tokens & tooling</li>
+                            <li>Accessibility foundations</li>
+                        </ul>
+                    </article>
+                    <article class="service">
+                        <h3>Front-end implementation</h3>
+                        <p>Bridge design and engineering by pairing on production-ready front-end code in React, Vue, or modern web stacks.</p>
+                        <ul>
+                            <li>Responsive layouts</li>
+                            <li>Performance optimization</li>
+                            <li>Team enablement</li>
+                        </ul>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section section--alt" id="experience">
+            <div class="container">
+                <div class="section__intro">
+                    <p class="eyebrow">Experience</p>
+                    <h2>Trusted by product and marketing teams alike.</h2>
+                </div>
+                <div class="timeline">
+                    <article class="timeline__item">
+                        <div class="timeline__year">2021 — Present</div>
+                        <div class="timeline__content">
+                            <h3>Independent Product Design Partner</h3>
+                            <p>Consulting with growth-stage SaaS teams on product vision, UX strategy, and front-end delivery.</p>
+                        </div>
+                    </article>
+                    <article class="timeline__item">
+                        <div class="timeline__year">2018 — 2021</div>
+                        <div class="timeline__content">
+                            <h3>Lead Product Designer · Flux Labs</h3>
+                            <p>Led a cross-disciplinary team delivering enterprise analytics tools used by Fortune 500 organizations.</p>
+                        </div>
+                    </article>
+                    <article class="timeline__item">
+                        <div class="timeline__year">2015 — 2018</div>
+                        <div class="timeline__content">
+                            <h3>UX Designer · Brightside</h3>
+                            <p>Designed customer onboarding flows and internal tools that reduced support volume by 30%.</p>
+                        </div>
+                    </article>
+                </div>
+            </div>
+        </section>
+
+        <section class="section" id="contact">
+            <div class="container contact">
+                <div class="contact__intro">
+                    <p class="eyebrow">Let’s collaborate</p>
+                    <h2>Ready to build something exceptional?</h2>
+                    <p>Share a few details about your product or idea and I’ll reach out within two business days with next steps.</p>
+                    <div class="contact__details">
+                        <a href="mailto:hello@alexjohnson.design">hello@alexjohnson.design</a>
+                        <a href="https://www.linkedin.com" target="_blank" rel="noreferrer">LinkedIn</a>
+                        <a href="https://dribbble.com" target="_blank" rel="noreferrer">Dribbble</a>
+                    </div>
+                </div>
+                <form class="contact__form">
+                    <label for="name">Name</label>
+                    <input id="name" name="name" type="text" placeholder="Your name" required>
+
+                    <label for="email">Email</label>
+                    <input id="email" name="email" type="email" placeholder="you@example.com" required>
+
+                    <label for="company">Company</label>
+                    <input id="company" name="company" type="text" placeholder="Company or team name">
+
+                    <label for="project">How can I help?</label>
+                    <textarea id="project" name="project" rows="4" placeholder="Tell me about your product, timeline, and goals"></textarea>
+
+                    <button type="submit" class="btn btn--primary">Send message</button>
+                </form>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container footer__content">
+            <span>© <span id="year"></span> Alex Johnson</span>
+            <span>Designing with empathy, building with intent.</span>
+        </div>
+    </footer>
+
+    <script src="assets/js/main.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the landing page markup with a structured hero, about, work, services, experience, and contact layout inspired by the provided reference
- refresh the design system with a light aesthetic, grid-driven sections, and responsive cards that better mirror the requested style
- simplify the JavaScript to power the mobile navigation toggle and dynamic footer year

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e1f878f798832d9831eef7368aa441